### PR TITLE
added needed helper in contactus controller for get_taxonomies method that is needed

### DIFF
--- a/app/controllers/spree/contact_us/contacts_controller.rb
+++ b/app/controllers/spree/contact_us/contacts_controller.rb
@@ -1,5 +1,6 @@
 class Spree::ContactUs::ContactsController < Spree::BaseController
 
+  helper "spree/products"
   def create
     @contact = Spree::ContactUs::Contact.new(params[:contact_us_contact])
 


### PR DESCRIPTION
this fixes the break if you upgrade to spree 1.1.3
