### PR TITLE
spree 3.1 stable changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 
 gemspec

--- a/app/models/spree/contact_us/contact.rb
+++ b/app/models/spree/contact_us/contact.rb
@@ -31,7 +31,7 @@ module Spree
 
       def save
         if self.valid?
-          Spree::ContactUs::ContactMailer.contact_email(self).deliver
+          Spree::ContactUs::ContactMailer.contact_email(self).deliver_now
           return true
         end
         return false

--- a/spec/controllers/spree/contact_us/contacts_controller_spec.rb
+++ b/spec/controllers/spree/contact_us/contacts_controller_spec.rb
@@ -13,9 +13,9 @@ describe Spree::ContactUs::ContactsController, type: :controller do
 
     it "should redirect to root path with no contact tracking flash message" do
       spree_post :create, :contact_us_contact => @contact_attributes
-      flash[:notice].should_not be_nil
-      flash[:contact_tracking].should be_nil
-      response.should redirect_to(spree.root_path)
+      expect(flash[:notice]).not_to be_nil
+      expect(flash[:contact_tracking]).to be_nil
+      expect(response).to redirect_to(spree.root_path)
     end
   end
 
@@ -26,17 +26,17 @@ describe Spree::ContactUs::ContactsController, type: :controller do
 
     it "should redirect to root path with both notice and conversion flash messages" do
       spree_post :create, :contact_us_contact => @contact_attributes
-      flash[:notice].should_not be_nil
-      flash[:contact_tracking].should == 'something'
-      response.should redirect_to(spree.root_path)
+      expect(flash[:notice]).not_to be_nil
+      expect(flash[:contact_tracking]).to eq 'something'
+      expect(response).to redirect_to(spree.root_path)
     end
   end
 
   context "prevent malicious posts" do
     it "should not error when contact_us_contact is not present" do
-      lambda do
+      expect do
       spree_post :create, {"utf8"=>"a", "g=contact_us_contact"=>{"nam"=>""}, "xtcontact_us_contact"=>{"emai"=>""}, "ilcontact_us_contact"=>{"messag"=>"ea_n"}, "l_comm"=>"itSend Messa"}
-      end.should_not raise_error
+      end.not_to raise_error
     end
   end
 end

--- a/spec/controllers/spree/contact_us/contacts_controller_spec.rb
+++ b/spec/controllers/spree/contact_us/contacts_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::ContactUs::ContactsController do
+describe Spree::ContactUs::ContactsController, type: :controller do
   before(:each) do
     SpreeContactUs.mailer_to = 'test@example.com'
     @contact_attributes = { :email => "Valid@Email.com", :message => "Test" }

--- a/spec/features/spree_contact_us_lint_spec.rb
+++ b/spec/features/spree_contact_us_lint_spec.rb
@@ -18,11 +18,11 @@ describe 'Contact Us page', type: :feature, js: true do
   it 'displays default contact form properly' do
     visit spree.contact_us_path
     within "form#new_contact_us_contact" do
-      page.should have_selector "input#contact_us_contact_email"
-      page.should have_selector "textarea#contact_us_contact_message"
-      page.should_not have_selector "input#contact_us_contact_name"
-      page.should_not have_selector "input#contact_us_contact_subject"
-      page.should have_selector "input#contact_us_contact_submit"
+      expect(page).to have_selector "input#contact_us_contact_email"
+      expect(page).to have_selector "textarea#contact_us_contact_message"
+      expect(page).not_to have_selector "input#contact_us_contact_name"
+      expect(page).not_to have_selector "input#contact_us_contact_subject"
+      expect(page).to have_selector "input#contact_us_contact_submit"
     end
   end
 
@@ -47,10 +47,10 @@ describe 'Contact Us page', type: :feature, js: true do
 
       it "The email should have been sent with the correct attributes" do
         mail = ActionMailer::Base.deliveries.last
-        mail.to.should == ['contact@please-change-me.com']
-        mail.from.should == ['test@example.com']
-        mail.text_part.body.should match 'howdy'
-        ActionMailer::Base.deliveries.size.should == 1
+        expect(mail.to).to eq ['contact@please-change-me.com']
+        expect(mail.from).to eq ['test@example.com']
+        expect(mail.text_part.body).to match 'howdy'
+        expect(ActionMailer::Base.deliveries.size).to eq 1
       end
     end
 
@@ -63,12 +63,12 @@ describe 'Contact Us page', type: :feature, js: true do
         end
 
         it "I should see two error messages" do
-          page.should have_content "Please enter a valid email address"
-          page.should have_content "This field is required"
+          expect(page).to have_content "Please enter a valid email address"
+          expect(page).to have_content "This field is required"
         end
 
         it "An email should not have been sent" do
-          ActionMailer::Base.deliveries.size.should == 0
+          expect(ActionMailer::Base.deliveries.size).to eq 0
         end
       end
     end
@@ -88,8 +88,8 @@ describe 'Contact Us page', type: :feature, js: true do
     end
 
     it "displays an input for name and subject" do
-      page.should have_selector "input#contact_us_contact_name"
-      page.should have_selector "input#contact_us_contact_subject"
+      expect(page).to have_selector "input#contact_us_contact_name"
+      expect(page).to have_selector "input#contact_us_contact_subject"
     end
 
     context "Submitting the form" do
@@ -105,17 +105,17 @@ describe 'Contact Us page', type: :feature, js: true do
         end
 
         it "I should be redirected to the homepage" do
-          current_path.should == "/"
+          expect(current_path).to eq "/"
         end
 
         it "The email should have been sent with the correct attributes" do
           mail = ActionMailer::Base.deliveries.last
-          mail.text_part.body.should match 'howdy'
-          mail.text_part.body.should match 'Jeff'
-          mail.from.should == ['test@example.com']
-          mail.subject.should match 'Testing contact form.'
-          mail.to.should == ['contact@please-change-me.com']
-          ActionMailer::Base.deliveries.size.should == 1
+          expect(mail.text_part.body).to match 'howdy'
+          expect(mail.text_part.body).to match 'Jeff'
+          expect(mail.from).to eq ['test@example.com']
+          expect(mail.subject).to match 'Testing contact form.'
+          expect(mail.to).to eq ['contact@please-change-me.com']
+          expect(ActionMailer::Base.deliveries.size).to eq 1
         end
       end
 
@@ -125,11 +125,11 @@ describe 'Contact Us page', type: :feature, js: true do
         end
 
         it "I should see error messages" do
-          page.should have_content "This field is required"
+          expect(page).to have_content "This field is required"
         end
 
         it "An email should not have been sent" do
-          ActionMailer::Base.deliveries.size.should == 0
+          expect(ActionMailer::Base.deliveries.size).to eq 0
         end
       end
     end

--- a/spec/features/spree_contact_us_lint_spec.rb
+++ b/spec/features/spree_contact_us_lint_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Contact Us page', js: true do
+describe 'Contact Us page', type: :feature, js: true do
 
   after do
     ActionMailer::Base.deliveries = []
@@ -37,10 +37,12 @@ describe 'Contact Us page', js: true do
         fill_in 'Email', :with => 'test@example.com'
         fill_in 'Message', :with => 'howdy'
         click_button 'Submit'
+
+        expect(page).to have_content I18n.t('spree.contact_us.notices.success') # wait until success
       end
 
-      it "I should be redirected to the homepage" do
-        current_path.should == "/"
+      it "I should be redirected to the homepage with success flash message" do
+        expect(current_path).to eq "/"
       end
 
       it "The email should have been sent with the correct attributes" do
@@ -98,6 +100,8 @@ describe 'Contact Us page', js: true do
           fill_in 'contact_us_contact[name]', :with => 'Jeff'
           fill_in 'contact_us_contact[subject]', :with => 'Testing contact form.'
           click_button 'Submit'
+
+          expect(page).to have_content I18n.t('spree.contact_us.notices.success') # wait until success
         end
 
         it "I should be redirected to the homepage" do

--- a/spec/lib/spree_contact_us_spec.rb
+++ b/spec/lib/spree_contact_us_spec.rb
@@ -11,13 +11,13 @@ describe SpreeContactUs do
   end
 
   it "should be valid" do
-    SpreeContactUs.should be_a(Module)
+    expect(SpreeContactUs).to be_a(Module)
   end
 
   describe 'setup block' do
     it 'should yield self' do
       SpreeContactUs.setup do |config|
-        SpreeContactUs.should eql(config)
+        expect(SpreeContactUs).to eql(config)
       end
     end
   end
@@ -25,28 +25,28 @@ describe SpreeContactUs do
   describe 'mailer_from' do
     it 'should be configurable' do
       SpreeContactUs.mailer_from = "contact@please-change-me.com"
-      SpreeContactUs.mailer_from.should eql("contact@please-change-me.com")
+      expect(SpreeContactUs.mailer_from).to eql("contact@please-change-me.com")
     end
   end
 
   describe 'mailer_to' do
     it 'should be configurable' do
       SpreeContactUs.mailer_to = "contact@changed-me.com"
-      SpreeContactUs.mailer_to.should eql("contact@changed-me.com")
+      expect(SpreeContactUs.mailer_to).to eql("contact@changed-me.com")
     end
   end
 
   describe 'require_name' do
     it 'should be configurable' do
       SpreeContactUs.require_name = true
-      SpreeContactUs.require_name.should eql(true)
+      expect(SpreeContactUs.require_name).to eql(true)
     end
   end
 
   describe 'require_subject' do
     it 'should be configurable' do
       SpreeContactUs.require_subject = true
-      SpreeContactUs.require_subject.should eql(true)
+      expect(SpreeContactUs.require_subject).to eql(true)
     end
   end
 

--- a/spec/mailers/spree/contact_us/contact_mailer_spec.rb
+++ b/spec/mailers/spree/contact_us/contact_mailer_spec.rb
@@ -10,13 +10,13 @@ describe Spree::ContactUs::ContactMailer do
     end
 
     it "should render successfully" do
-      lambda { Spree::ContactUs::ContactMailer.contact_email(@contact) }.should_not raise_error
+      expect{ Spree::ContactUs::ContactMailer.contact_email(@contact) }.not_to raise_error
     end
 
     it "should use the ContactUs.mailer_from setting when it is set" do
       SpreeContactUs.mailer_from = "contact@please-change-me.com"
       @mailer = Spree::ContactUs::ContactMailer.contact_email(@contact)
-      @mailer.from.should eql([SpreeContactUs.mailer_from])
+      expect(@mailer.from).to eql([SpreeContactUs.mailer_from])
       SpreeContactUs.mailer_from = nil
     end
 
@@ -27,33 +27,33 @@ describe Spree::ContactUs::ContactMailer do
       end
 
       it "should have the initializers to address" do
-        @mailer.to.should eql([SpreeContactUs.mailer_to])
+        expect(@mailer.to).to eql([SpreeContactUs.mailer_to])
       end
 
       it "should use the users email in the from field when ContactUs.mailer_from is not set" do
-        @mailer.from.should eql([@contact.email])
+        expect(@mailer.from).to eql([@contact.email])
       end
 
       it "should use the users email in the reply_to field" do
-        @mailer.reply_to.should eql([@contact.email])
+        expect(@mailer.reply_to).to eql([@contact.email])
       end
 
       it "should have users email in the subject line" do
-        @mailer.subject.should eql("Contact Us message from #{@contact.email}")
+        expect(@mailer.subject).to eql("Contact Us message from #{@contact.email}")
       end
 
       it "should have the message in the body" do
-        @mailer.body.should match("<p>Thanks!</p>")
+        expect(@mailer.body).to match("<p>Thanks!</p>")
       end
 
       it "should deliver successfully" do
-        lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.should_not raise_error
+        expect{ Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.not_to raise_error
       end
 
       describe "and delivered" do
 
         it "should be added to the delivery queue" do
-          lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.should change(ActionMailer::Base.deliveries,:size).by(1)
+          expect{ Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.to change(ActionMailer::Base.deliveries,:size).by(1)
         end
 
       end

--- a/spec/mailers/spree/contact_us/contact_mailer_spec.rb
+++ b/spec/mailers/spree/contact_us/contact_mailer_spec.rb
@@ -47,13 +47,13 @@ describe Spree::ContactUs::ContactMailer do
       end
 
       it "should deliver successfully" do
-        lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver }.should_not raise_error
+        lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.should_not raise_error
       end
 
       describe "and delivered" do
 
         it "should be added to the delivery queue" do
-          lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver }.should change(ActionMailer::Base.deliveries,:size).by(1)
+          lambda { Spree::ContactUs::ContactMailer.contact_email(@contact).deliver_now }.should change(ActionMailer::Base.deliveries,:size).by(1)
         end
 
       end

--- a/spec/models/spree/contact_us/contact_spec.rb
+++ b/spec/models/spree/contact_us/contact_spec.rb
@@ -9,27 +9,27 @@ describe Spree::ContactUs::Contact do
       params = {:email => "test@example.com", :message => "message"}
       params.default = "foo"
       contact = described_class.new(params)
-      contact.subject.should_not == "foo"
+      expect(contact.subject).not_to eq "foo"
     end
 
     it "should scrub attributes" do
-      lambda {
+      expect{
         described_class.new(:email => "test@example.com", :message => "foo", :destroy => true)
-      }.should_not raise_error
+      }.not_to raise_error
     end
 
     it "should not allow bypass of validation" do
       v = described_class.new(:email => "test@example.com", :message => "foo", "validation_context" => "update")
-      v.validation_context.should_not == "update"
+      expect(v.validation_context).not_to eq "update"
     end
   end
 
   describe "Validations" do
 
-    it {should validate_presence_of(:email)}
-    it {should validate_presence_of(:message)}
-    it {should_not validate_presence_of(:name)}
-    it {should_not validate_presence_of(:subject)}
+    it {is_expected.to validate_presence_of(:email)}
+    it {is_expected.to validate_presence_of(:message)}
+    it {is_expected.not_to validate_presence_of(:name)}
+    it {is_expected.not_to validate_presence_of(:subject)}
 
     context 'with name and subject settings' do
 
@@ -43,8 +43,8 @@ describe Spree::ContactUs::Contact do
         SpreeContactUs.require_subject =true
       end
 
-      it {should validate_presence_of(:name)}
-      it {should validate_presence_of(:subject)}
+      it {is_expected.to validate_presence_of(:name)}
+      it {is_expected.to validate_presence_of(:subject)}
 
     end
 
@@ -55,8 +55,8 @@ describe Spree::ContactUs::Contact do
     describe '#read_attribute_for_validation' do
       it 'should return attributes set during initialization' do
         contact = Spree::ContactUs::Contact.new(:email => "Valid@Email.com", :message => "Test")
-        contact.read_attribute_for_validation(:email).should eql("Valid@Email.com")
-        contact.read_attribute_for_validation(:message).should eql("Test")
+        expect(contact.read_attribute_for_validation(:email)).to eql("Valid@Email.com")
+        expect(contact.read_attribute_for_validation(:message)).to eql("Test")
       end
     end
 
@@ -64,21 +64,21 @@ describe Spree::ContactUs::Contact do
 
       it 'should return false if records invalid' do
         contact = Spree::ContactUs::Contact.new(:email => "Valid@Email.com", :message => "")
-        contact.save.should eql(false)
+        expect(contact.save).to eql(false)
       end
 
       it 'should send email and return true if records valid' do
         mail = Mail.new(:from=>"Valid@Email.com", :to => "test@test.com")
-        mail.stub(:deliver_now).and_return(true)
+        allow(mail).to receive(:deliver_now).and_return(true)
         contact = Spree::ContactUs::Contact.new(:email => "Valid@Email.com", :message => "Test")
-        Spree::ContactUs::ContactMailer.should_receive(:contact_email).with(contact).and_return(mail)
-        contact.save.should eql(true)
+        expect(Spree::ContactUs::ContactMailer).to receive(:contact_email).with(contact).and_return(mail)
+        expect(contact.save).to eql(true)
       end
 
     end
 
     describe '#to_key' do
-      it { subject.should respond_to(:to_key) }
+      it { expect(subject).to respond_to(:to_key) }
     end
 
   end

--- a/spec/models/spree/contact_us/contact_spec.rb
+++ b/spec/models/spree/contact_us/contact_spec.rb
@@ -69,7 +69,7 @@ describe Spree::ContactUs::Contact do
 
       it 'should send email and return true if records valid' do
         mail = Mail.new(:from=>"Valid@Email.com", :to => "test@test.com")
-        mail.stub(:deliver).and_return(true)
+        mail.stub(:deliver_now).and_return(true)
         contact = Spree::ContactUs::Contact.new(:email => "Valid@Email.com", :message => "Test")
         Spree::ContactUs::ContactMailer.should_receive(:contact_email).with(contact).and_return(mail)
         contact.save.should eql(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
   end
 
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
-  config.before :each do
+  config.before :each do |example|
     DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end

--- a/spree_contact_us.gemspec
+++ b/spree_contact_us.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.1.0.beta'
+  s.add_dependency 'spree_core', '~> 3.1.0'
 
   s.add_development_dependency 'capybara',         '~> 2.1'
   s.add_development_dependency 'coffee-rails'
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl',     '~> 4.2'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'generator_spec',   '~> 0.8'
-  s.add_development_dependency 'rspec-rails',      '~> 2.13'
-  s.add_development_dependency 'sass-rails',       '~> 4.0.2'
+  s.add_development_dependency 'rspec-rails',      '~> 3.2.3'
+  s.add_development_dependency 'sass-rails',       '~> 5.0.6'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'shoulda-matchers', '~> 2.0'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
* switched to spree_core 3.1.0 stable
* use `mail.deliver_now` instead of deprecated `mail.deliver`
* rspec 3 refactorings & fixes