### PR TITLE
Fixes errors with changing url and page refresh after invalid form sent

### DIFF
--- a/app/views/spree/contact_us/contacts/new.html.erb
+++ b/app/views/spree/contact_us/contacts/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @contact } %>
+<%= render partial: 'spree/shared/error_messages', locals: { target: @contact } %>
 
 <div class="contact-us">
   <div class="container">
@@ -22,7 +22,7 @@
           <%= Spree.t('spree_contact_us.left_title') %>
         </div>
 
-        <%= form_for @contact, :url => contacts_path, :html => { :novalidate => '' } do |f| %>
+        <%= form_for @contact, url: contact_us_path, html: { novalidate: '' } do |f| %>
 
           <% if SpreeContactUs.require_name %>
             <%= f.text_field :name, class: 'required col-12 mt-3 mb-1 mb-lg-2', placeholder: true %>
@@ -35,8 +35,8 @@
           <% end %>
             <%= f.text_area :message, class: 'required col-12 mt-3 mb-3', rows: 4, placeholder: Spree.t('spree_contact_us.message_placeholder') %>
           <div class="text-center text-lg-left mt-lg-1 mb-4">
-            <%= f.submit Spree.t(:send), :alt => Spree.t(:send), :id => 'contact_us_contact_submit', :title => Spree.t(:send),
-                :class => 'col-7 col-lg-4 mb-4 mb-lg-0 btn btn-primary text-uppercase font-weight-bold'
+            <%= f.submit Spree.t(:send), alt: Spree.t(:send), id: 'contact_us_contact_submit', title: Spree.t(:send),
+                class: 'col-7 col-lg-4 mb-4 mb-lg-0 btn btn-primary text-uppercase font-weight-bold'
             %>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Spree::Core::Engine.add_routes do
   resources :contacts, controller: 'contact_us/contacts', only: %i[new create]
   get 'contact-us' => 'contact_us/contacts#new', as: :contact_us
+  post 'contact-us' => 'contact_us/contacts#create'
 end

--- a/spec/features/spree_contact_us_lint_spec.rb
+++ b/spec/features/spree_contact_us_lint_spec.rb
@@ -72,6 +72,17 @@ describe 'Contact Us page', type: :feature, js: true do
         it 'An email should not have been sent' do
           expect(ActionMailer::Base.deliveries.size).to eql(0)
         end
+
+        it 'does not change page url' do
+          expect(page).to have_current_path(spree.contact_us_path)
+        end
+
+        it 'does not show error after page refresh' do
+          visit current_path
+
+          expect(page).to have_field('contact_us_contact_message')
+          expect(page).to have_button('Send')
+        end
       end
     end
   end


### PR DESCRIPTION
Error found while adding the extension to other projects: When invalid form contents are sent errors show up on `/contacts` not `/contact-us` page. If a user reloads the page with errors it will result in a 404 error.