### PR TITLE
[SDP-286] Shows invalid email error only when email is present

### DIFF
--- a/app/models/spree/contact_us/contact.rb
+++ b/app/models/spree/contact_us/contact.rb
@@ -16,8 +16,8 @@ module Spree
         [^\s.@] # non-at-sign and non-period character
       \z/x.freeze
 
-      validates :email,   format: { with: EMAIL_REGEX },
-                          presence: true
+      validates :email,   presence: true
+      validates :email,   format: { with: EMAIL_REGEX }, if: -> { email.present? }
       validates :message, presence: true
       validates :name,    presence: { if: proc { SpreeContactUs.require_name } }
       validates :subject, presence: { if: proc { SpreeContactUs.require_subject } }

--- a/spec/features/spree_contact_us_lint_spec.rb
+++ b/spec/features/spree_contact_us_lint_spec.rb
@@ -83,6 +83,22 @@ describe 'Contact Us page', type: :feature, js: true do
           expect(page).to have_field('contact_us_contact_message')
           expect(page).to have_button('Send')
         end
+
+        it 'shows only invalid email error for email field' do
+          expect(page).not_to have_content "Email can't be blank"
+        end
+      end
+
+      context 'Email is blank' do
+        before do
+          fill_in 'Email', with: ''
+          fill_in 'Message', with: ''
+          click_button 'Send'
+        end
+
+        it 'shows only email blank error for email field' do
+          expect(page).not_to have_content 'Email is invalid'
+        end
       end
     end
   end


### PR DESCRIPTION
Shows email invalid errors only when the email field is not blank. From the UX perspective, having multiple errors might be confusing to the end-user.