### PR TITLE
Change tag in header to h1

### DIFF
--- a/app/views/spree/contact_us/contacts/new.html.erb
+++ b/app/views/spree/contact_us/contacts/new.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-12 mb-lg-4 pt-lg-2 pb-lg-3 text-center text-lg-left">
-        <div class="px-3 px-lg-0 pt-lg-1 my-5 contact-us-header"><%= Spree.t('spree_contact_us.header') %></div>
+        <h1 class="px-3 px-lg-0 pt-lg-1 my-5 contact-us-header"><%= Spree.t('spree_contact_us.header') %></h1>
       </div>
       <div class="col-12 col-lg-6 text-center text-lg-left">
         <div class="pt-2 pb-lg-1 mb-3 contact-us-subheader">


### PR DESCRIPTION
Considering SEO, we should have at least one h1 tag on each page.

In SEMrush SEO reports we get a warning called `Missing h1`.
<img width="709" alt="Screenshot 2021-03-01 at 14 10 36" src="https://user-images.githubusercontent.com/43354669/109501546-03a9a800-7a98-11eb-9c2a-a2bd49a75bd2.png">